### PR TITLE
set MarlinTrkSys configuration per event

### DIFF
--- a/src/ForwardTracking/ForwardTracking.cc
+++ b/src/ForwardTracking/ForwardTracking.cc
@@ -324,6 +324,11 @@ void ForwardTracking::processRunHeader( LCRunHeader* ) {
 
 void ForwardTracking::processEvent( LCEvent * evt ) { 
 
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trkSystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trkSystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trkSystem,_SmoothOn) ;
+ 
    streamlog_out( DEBUG4 ) << "processing event number " << _nEvt << "\n";
    
    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/ForwardTracking/SiliconEndcapTracking.cc
+++ b/src/ForwardTracking/SiliconEndcapTracking.cc
@@ -358,7 +358,12 @@ void SiliconEndcapTracking::processRunHeader( LCRunHeader* ) {
 
 void SiliconEndcapTracking::processEvent( LCEvent * evt ) {
 
-   streamlog_out( DEBUG4 ) << "processing event number " << _nEvt << "\n";
+  // set the correct configuration for the tracking system for this event 
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useQMS>       mson( _trkSystem,  _MSOn ) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::usedEdx>      elosson( _trkSystem,_ElossOn) ;
+  MarlinTrk::TrkSysConfig< MarlinTrk::IMarlinTrkSystem::CFG::useSmoothing> smoothon( _trkSystem,_SmoothOn) ;
+
+  streamlog_out( DEBUG4 ) << "processing event number " << _nEvt << "\n";
    
    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    //                                                                                                              //


### PR DESCRIPTION

BEGINRELEASENOTES
- set correct MarlinTrkSystem configuration for every event with `MarlinTrk::TrkSysConfig`

ENDRELEASENOTES

needs: https://github.com/iLCSoft/MarlinTrk/pull/7